### PR TITLE
Initial real commit with skeletal Post index view and creation form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,6 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,11 +119,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    spring (2.0.1)
-      activesupport (>= 4.2)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -163,8 +158,6 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.2)
   sass-rails (~> 5.0)
-  spring
-  spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/posts.coffee
+++ b/app/assets/javascripts/posts.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the posts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,14 @@
+class PostsController < ApplicationController
+  def index
+    @posts = Post.all.order('id DESC')
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.create!(params.require(:post).permit(:title, :body))
+    redirect_to action: 'index'
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,17 @@
+<div style="float:right">
+  <%= link_to 'New post', new_post_path %>
+</div>
+
+<% @posts.each do |post| %>
+  <h3><%= post.title %></h3>
+  <article>
+    <%= post.body %>
+  </article>
+  <hr/>
+<% end %>
+
+<ul>
+  <li>FOO_CONFIG: <%= ENV['FOO_CONFIG'].inspect %></li>
+  <li>RAILS_ENV: <%= ENV['RAILS_ENV'].inspect %></li>
+  <li>Rails.env: <%= Rails.env.inspect %></li>
+</ul>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,11 @@
+<%= form_for @post do |f| %>
+  <div>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+  <div>
+    <%= f.label :body %>
+    <%= f.text_area :body, size: '60x12' %>
+  </div>
+  <%= f.submit 'Create' %>
+<% end %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,9 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
+  username: <%= ENV['DATABASE_USER'] %>
+  password: <%= ENV['DATABASE_PASS'] %>
 
 development:
   <<: *default
@@ -81,5 +84,3 @@ test:
 production:
   <<: *default
   database: hokusai_demo_production
-  username: hokusai_demo
-  password: <%= ENV['HOKUSAI_DEMO_DATABASE_PASSWORD'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root to: 'posts#index'
+  resources :posts
 end

--- a/db/migrate/20170308175946_create_posts.rb
+++ b/db/migrate/20170308175946_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170308175946) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string   "title"
+    t.text     "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/integration/post_flow_test.rb
+++ b/test/integration/post_flow_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class PostFlowTest < ActionDispatch::IntegrationTest
+  test 'creates post' do
+    get '/posts/new'
+    assert_response :success
+    assert_select 'input#post_title'
+    assert_select 'textarea#post_body'
+
+    post '/posts', params: { post: { title: 'test1', body: 'test2' } }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_select 'h3', 'test1'
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This repo's initial commit (https://github.com/joeyAghion/hokusai_demo/commit/9b45925cd142a1c94be4585c3ef8ac01d7cc20ab) consists of only what's generated by:

    rails new hokusai_demo --database=postgresql

This PR adds some minimal stuff to actually run the project locally, and basic list and create views for a skeletal `Post` model. Also:

* removed `spring` to avoid cached dependency headaches
* tweaked the `database.yml` to work with typical local postgres
* added a basic integration test exercising the new actions

Basically my operations were:

    rake db:setup
    rake db:migrate
    rails g model Post # add columns to generated migration...
    spring stop # remove spring-related gems from Gemfile and re-bundle...
    rails g controller posts # add controller actions, update routes.rb, create views...

CC: @cavvia