### PR TITLE
Initial docker/hokusai dev and test command working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.3.3
+RUN apt-get update -qq && \
+  apt-get install -y nodejs && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN gem install bundler
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+# Set up working directory
+RUN mkdir /app
+
+# Set up gems
+WORKDIR /tmp
+ADD Gemfile Gemfile
+ADD Gemfile.lock Gemfile.lock
+RUN bundle install -j4
+
+# Finally, add the rest of our app's code
+# (this is done at the end so that changes to our app's code
+# don't bust Docker's cache)
+ADD . /app
+WORKDIR /app
+
+ENV PORT 80
+EXPOSE 80

--- a/hokusai/common.yml
+++ b/hokusai/common.yml
@@ -1,0 +1,8 @@
+---
+version: '2'
+services:
+  hokusai-demo:
+    build: ../
+    environment:
+    - DATABASE_HOST=db
+    - DATABASE_USER=postgres

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,0 +1,4 @@
+---
+aws-account-id: '585031190124'
+aws-ecr-region: us-east-1
+project-name: hokusai-demo

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,0 +1,12 @@
+---
+version: '2'
+services:
+  web:
+    command: bundle exec puma
+    extends:
+      file: common.yml
+      service: hokusai-demo
+    ports:
+    - 8080:80
+  db:
+    image: postgres:9.5

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -1,0 +1,10 @@
+---
+version: '2'
+services:
+  hokusai-demo:
+    command: bundle exec rake db:setup test
+    extends:
+      file: common.yml
+      service: hokusai-demo
+  db:
+    image: postgres:9.5


### PR DESCRIPTION
Adds `Dockerfile` and simple development and test hokusai YAML.

Basically I started from the Hokusai rack template and modified some things:

    hokusai init --aws-account-id 585031190124 --framework rack --base-image ruby:2.3.3
    # edited common.yml, development.yml, and test.yml's command, env, ports; added db service
    # edited Dockerfile to add nodejs and remove CMD
    hokusai dev # starts up web/db containers (but no db)
    docker exec -it hokusai_web_1 bash # connect to running dev container and open console
    $ bundle exec rake db:setup # site now available at localhost:8080 # create dev database
    $ exit
    hokusai test # works!

Next will be to set up a staging YAML, a corresponding docker repository, and finally the Kubernetes deployment.