### PR TITLE
Https config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -48,10 +48,21 @@ metadata:
     app: hokusai-demo
   name: hokusai-demo
   namespace: default
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2016-01-19_artsy-net-wildcard"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
 spec:
   ports:
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 80
   - port: 80
     protocol: TCP
+    name: http
     targetPort: 80
   selector:
     app: hokusai-demo


### PR DESCRIPTION
Force https now works.  We should follow this pattern for our rails deployments.

See: http://a0988dae6045611e79998120d04ee1f4-364914899.us-east-1.elb.amazonaws.com

